### PR TITLE
add * into wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 ]
 
 [tool.setuptools.packages.find]
+where = ["."]
 include = ["sam_audio*"]
 
 [tool.ruff]


### PR DESCRIPTION
In the original repository, `sam_audio/models` is not included in the built wheel.
As a result, when installing the package using tools like uv, `from sam_audio import SAMAudio` fails because the required modules are missing from the installation.