### PR TITLE
Update Python version requirement to 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ SAM-Audio and the Judge model crucially rely on [Perception-Encoder Audio-Visual
 ## Setup
 
 **Requirements:**
-- Python >= 3.10
+- Python >= 3.11
 - CUDA-compatible GPU (recommended)
 
 Install dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 
 readme = "README.md"
 license = { file="LICENSE" }
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "dacvae@git+https://github.com/facebookresearch/dacvae.git",
     "audiobox_aesthetics",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 
 readme = "README.md"
 license = { file="LICENSE" }
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "dacvae@git+https://github.com/facebookresearch/dacvae.git",
     "audiobox_aesthetics",
@@ -36,7 +36,7 @@ include = ["sam_audio*"]
 
 [tool.ruff]
 
-target-version = "py310"
+target-version = "py311"
 
 lint.select=[
     "B",


### PR DESCRIPTION
This change resolves an issue with running the project using `uv` for a virtual environment.

```
uv sync
    Updated https://github.com/facebookresearch/perception_models (e72b6810b1133e1c879f2cc965d276eb73803f1f)
    Updated https://github.com/facebookresearch/dacvae.git (414c20785fc3a28373073ea8ef7a1316eeeaca6e)
    Updated https://github.com/facebookresearch/ImageBind.git (53680b02d7e37b19b124fa37bae4b6c98c38f5be)
    Updated https://github.com/facebookresearch/pytorchvideo.git (6cdc929315aab1b5674b6dcf73b16ec99147735f)
  × No solution found when resolving dependencies:
  ╰─▶ Because the requested Python version (>=3.10) does not satisfy Python>=3.11 and perception-models==1.0.0 depends
      on Python>=3.11, we can conclude that perception-models==1.0.0 cannot be used.
      And because only perception-models==1.0.0 is available and your project depends on perception-models, we can
      conclude that your project's requirements are unsatisfiable.

      hint: The `requires-python` value (>=3.10) includes Python versions that are not supported by your dependencies
      (e.g., perception-models==1.0.0 only supports >=3.11). Consider using a more restrictive `requires-python` value
      (like >=3.11).
```