### PR TITLE
Place anchors on same device as audio

### DIFF
--- a/sam_audio/processor.py
+++ b/sam_audio/processor.py
@@ -119,8 +119,8 @@ class Batch:
             anchor_ids = pad_sequence(
                 ids, batch_first=True, padding_value=anchor_dict["<pad>"]
             )
-        self.anchor_ids = anchor_ids
-        self.anchor_alignment = anchor_alignment
+        self.anchor_ids = anchor_ids.to(self.audios.device)
+        self.anchor_alignment = anchor_alignment.to(self.audios.device)
         self.anchors = anchors
 
 


### PR DESCRIPTION
When doing span prediction, we may create new
anchor ids/alignment.  We nened to place these tensors on the same device as `self.audios` in case the user has already moved the batch to device