### PR TITLE
Fix huggingface_hub >= 1.0 compatibility in BaseModel._from_pretrained

### DIFF
--- a/sam_audio/model/base.py
+++ b/sam_audio/model/base.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved\n
+# Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved
 
 import json
 import os
@@ -21,10 +21,10 @@ class BaseModel(torch.nn.Module, ModelHubMixin):
         model_id: str,
         cache_dir: str,
         force_download: bool,
-        proxies: Optional[Dict],
-        resume_download: bool,
-        local_files_only: bool,
-        token: Union[str, bool, None],
+        proxies: Optional[Dict] = None,
+        resume_download: Optional[bool] = None,
+        local_files_only: bool = False,
+        token: Union[str, bool, None] = None,
         map_location: str = "cpu",
         strict: bool = True,
         revision: Optional[str] = None,
@@ -38,8 +38,6 @@ class BaseModel(torch.nn.Module, ModelHubMixin):
                 revision=cls.revision,
                 cache_dir=cache_dir,
                 force_download=force_download,
-                proxies=proxies,
-                resume_download=resume_download,
                 token=token,
                 local_files_only=local_files_only,
             )


### PR DESCRIPTION
## Problem

`huggingface_hub >= 1.0` removed `proxies` and `resume_download` from the keyword arguments passed by `ModelHubMixin.from_pretrained()` to the user-defined `_from_pretrained()` hook. This causes a `TypeError` at model load time with any recent installation:

```
TypeError: BaseModel._from_pretrained() missing 2 required keyword-only
arguments: 'proxies' and 'resume_download'
```

Reported in #85, #89, and #90. The workarounds suggested there (downgrading `huggingface_hub` to 0.36.0 or hardcoding default values) are fragile and break other dependencies.

## Fix

- Make `proxies`, `resume_download`, `local_files_only`, and `token` optional with `None`/`False` defaults in `_from_pretrained()`, matching the new `ModelHubMixin` contract.
- Remove `proxies` and `resume_download` from the `snapshot_download()` call: both parameters have been removed from `snapshot_download`'s signature in `huggingface_hub >= 1.0` and passing them would raise a `TypeError` there as well.

## Tested with

- `huggingface_hub==1.10.1` + `transformers==5.5.3`

Verified end-to-end: `SAMAudio.from_pretrained()` loads without error, `model.separate()` produces valid output on real audio.