### PR TITLE
Fix: Predicted spans NOT being used for anchor conditioning when `predict_spans=True`

### DIFF
--- a/sam_audio/model/model.py
+++ b/sam_audio/model/model.py
@@ -267,11 +267,16 @@ class SAMAudio(BaseModel):
                 ),
             )
 
-            forward_args["anchor_ids"] = self._repeat_for_reranking(
-                batch.anchor_ids, reranking_candidates
-            )
-            forward_args["anchor_alignment"] = self._repeat_for_reranking(
-                batch.anchor_alignment, reranking_candidates
+            # Refresh anchor conditioning created by predict_spans()
+            forward_args.update(
+                {
+                    "anchor_ids": self._repeat_for_reranking(
+                        batch.anchor_ids, reranking_candidates
+                    ),
+                    "anchor_alignment": self._repeat_for_reranking(
+                        batch.anchor_alignment, reranking_candidates
+                    ),
+                }
             )
 
         audio_features = forward_args["audio_features"]

--- a/sam_audio/model/model.py
+++ b/sam_audio/model/model.py
@@ -267,6 +267,13 @@ class SAMAudio(BaseModel):
                 ),
             )
 
+            forward_args["anchor_ids"] = self._repeat_for_reranking(
+                batch.anchor_ids, reranking_candidates
+            )
+            forward_args["anchor_alignment"] = self._repeat_for_reranking(
+                batch.anchor_alignment, reranking_candidates
+            )
+
         audio_features = forward_args["audio_features"]
         B, T, C = audio_features.shape
         C = C // 2  # we stack audio_features, so the actual channels is half


### PR DESCRIPTION
## Description

This fixes stale anchor conditioning when `predict_spans=True`.

Currently, `SAMAudio.separate()` populates `forward_args` before `predict_spans()` is executed.
If no anchors are initially provided in the `batch`, `forward_args` retains `None` or empty tensors for `anchor_ids` and `anchor_alignment`.

However, `predict_spans()` mutates the `batch` by adding predicted anchors through `batch.process_anchors(...)`, while `forward_args` is never updated afterward.

As a result, the inference continues without any anchor conditioning, ignoring the predicted spans entirely.

## Change

After automatic span prediction, refresh:

- `forward_args["anchor_ids"]`
- `forward_args["anchor_alignment"]`

using the updated batch values and the existing reranking repeat helper.

## Notes

I believe this is a significant bug, as it considerably affects output reliability, which is a key aspect highlighted in the paper.
